### PR TITLE
use optimize=both behavior by default

### DIFF
--- a/src/program/newEntryPoint.js
+++ b/src/program/newEntryPoint.js
@@ -94,6 +94,7 @@ function parseMain(mainSrc, moduleSrcs, errorCollector) {
         moduleSrcs,
         errorCollector
     )
+    errorCollector.throw()
 
     const mainImports = modules[0].filterDependencies(imports)
 


### PR DESCRIPTION
 - when no optimize:boolean is provided, uses default CompileOptions
 - added withAlt option to CompileOption
 - optimize=true is now the default
 - withAlt=true is the default, unless optimize=false was explicitly set

!!! needs updated deps

- needs https://github.com/HeliosLang/uplc/pull/2

- no longer needs https://github.com/HeliosLang/compiler-utils/pull/3